### PR TITLE
Use secrandom library instead of /dev/urandom directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+deps/
 coverage/
 *.o
 *.so

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/secrandom"]
+	path = deps/secrandom
+	url = git@github.com:mah0x211/secrandom.git

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 [![codecov](https://codecov.io/gh/mah0x211/lua-os-urandom/branch/master/graph/badge.svg)](https://codecov.io/gh/mah0x211/lua-os-urandom)
 
 
-`lua-os-urandom` is a Lua module for safely obtaining random bytes and random integers from the operating system's entropy source `/dev/urandom`.
+`lua-os-urandom` is a Lua module for safely obtaining random bytes and random integers from;
+
+- the operating system's secure random number generator (RNG) such as `/dev/urandom` on Unix-like systems, or
+- Use the OpenSSL library if it is available.
 
 
 ## Installation
@@ -20,8 +23,8 @@ luarocks install os-urandom
 local dump = require('dump')
 local urandom = require('os.urandom')
 
--- open a `/dev/urandom` file descriptor and return an instance of os.urandom
-local u = assert(urandom())
+-- create an instance of os.urandom
+local u = urandom()
 print(u) -- os.urandom: 0x600003e308d8
 
 -- get the 5 bytes of string from the internal buffer.
@@ -58,7 +61,7 @@ print(dump(arr))
 --     [4] = 1269583660
 -- }
 
--- close the `/dev/urandom` file descriptor.
+-- close the `/dev/urandom` file descriptor if it is opened.
 -- you cannot use this instance after calling this method.
 u:close()
 ```
@@ -69,36 +72,25 @@ u:close()
 the following functions return an `error` object created by https://github.com/mah0x211/lua-errno module.
 
 
-## u, err = urandom( [pathname] )
+## u = urandom()
 
-open `/dev/urandom` or specified pathname and return an instance of `os.urandom`.
-
-**Parameters**
-
-- `pathname:string?`: path to the random source. if omitted, `/dev/urandom` will be opened by default.
+return an instance of `os.urandom`.
 
 **Returns**
 
 - `u:os.urandom`: an `os.urandom` object.
-- `err:any`: an error object if the operation fails.
 
 **Example**
 
 ```lua
 local urandom = require('os.urandom')
-
--- open the default random source (`/dev/urandom`).
-local u = assert(urandom())
-print(u) -- os.urandom: ...
-
--- open a custom random source.
-u = assert(urandom('/dev/random'))
+local u = urandom()
 print(u) -- os.urandom: ...
 ```
 
 ## urandom:close()
 
-close the `/dev/urandom` file descriptor and free the internal buffer. you cannot use this instance after calling this method.
+close the `/dev/urandom` file descriptor if it is opened.
 
 
 ## s, err = urandom:bytes( nbyte )
@@ -108,7 +100,6 @@ get specified number of bytes as a string.
 **Parameters**
 
 - `nbyte:pint`: number of bytes to get.
-- `offset:pint`: starting byte offset. defaults to `1`.
 
 **Returns**
 
@@ -143,7 +134,7 @@ same as `urandom:get8u()`.
 same as `urandom:get8u()`.
 
 
-## arr, err = urandom:get32u( [count] [, offset] )
+## arr, err = urandom:get32u( count )
 
 get uint32 integers.
 


### PR DESCRIPTION
This pull request introduces significant updates to the `lua-os-urandom` module, transitioning its random number generation logic to use the `secrandom` library instead of directly accessing `/dev/urandom`. It also simplifies the API by removing support for custom random source paths and enhances error handling for edge cases like buffer overflow. The changes span across documentation, implementation, and tests.

### Updates to Random Number Generation

* [`src/urandom.c`](diffhunk://#diff-12411905553bf4418b49efcb470e43c80a0d3289af6b546e9f425ee0c5652bc4R31-R38): Integrated the `secrandom` library for secure random number generation, replacing direct file descriptor operations with `secrandom()` calls. Removed logic for opening and reading from `/dev/urandom`. Added overflow checks to prevent errors when calculating buffer sizes. [[1]](diffhunk://#diff-12411905553bf4418b49efcb470e43c80a0d3289af6b546e9f425ee0c5652bc4R31-R38) [[2]](diffhunk://#diff-12411905553bf4418b49efcb470e43c80a0d3289af6b546e9f425ee0c5652bc4L51-R62) [[3]](diffhunk://#diff-12411905553bf4418b49efcb470e43c80a0d3289af6b546e9f425ee0c5652bc4L96-R86) [[4]](diffhunk://#diff-12411905553bf4418b49efcb470e43c80a0d3289af6b546e9f425ee0c5652bc4L106-R109)

### API Simplification

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R10): Updated documentation to reflect the simplified API, removing references to custom random source paths and emphasizing the use of secure RNGs like OpenSSL or `/dev/urandom`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L72-R93) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L111) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L146-R137)

### Test Enhancements

* [`test/urandom_test.lua`](diffhunk://#diff-8a50e750e29d19ab51f9b071ce230e5eadfa16e2418dff5fdd5a9a599321b322L7-R12): Modified tests to align with the new API. Added a new test case to validate proper error handling for buffer overflow scenarios. Updated tests for `close()` to ensure the instance remains usable after closing the file descriptor. [[1]](diffhunk://#diff-8a50e750e29d19ab51f9b071ce230e5eadfa16e2418dff5fdd5a9a599321b322L7-R12) [[2]](diffhunk://#diff-8a50e750e29d19ab51f9b071ce230e5eadfa16e2418dff5fdd5a9a599321b322R66-R98)

### Submodule Integration

* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R1-R3): Added the `secrandom` library as a submodule to the project.
* [`deps/secrandom`](diffhunk://#diff-5c988e15a343b15c351a18063a7fecb91726290b2d2ab1232925a2aa4edf9c01R1): Linked the `secrandom` submodule commit in the repository.